### PR TITLE
form.action tag removed

### DIFF
--- a/index.php
+++ b/index.php
@@ -81,7 +81,7 @@ ob_end_flush();
   <body>
 
     <div class="container">
-    	<form class="form-signin" action="/" method="post">
+    	<form class="form-signin" method="post">
         	<h3 class="form-signin-heading">
 			<?php 
 				if (isset($_POST['submit']))


### PR DESCRIPTION
When script is not deployed at root of the web server, clicking on the buttun change URL to "/". 

This is the fix.
