### PR TITLE
change PHP to php - header already sent error on RPI was resolved with that

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?PHP /*
+<?php /*
 Remote Wake/Sleep-On-LAN Server
 https://github.com/sciguy14/Remote-Wake-Sleep-On-LAN-Server
 Original Author: Jeremy E. Blum (http://www.jeremyblum.com)


### PR DESCRIPTION
I was having header already sent errors while installing your software on my RPi. I changed <?PHP to <?php in index.php and the problem was solved for me