### PR TITLE
More flexible sleep configration

### DIFF
--- a/config_sample.php
+++ b/config_sample.php
@@ -31,15 +31,10 @@
 	// This is the LOCAL IP address of the computer you are trying to wake.  Use a reserved DHCP through your router's administration interface to ensure it doesn't change.
 	$COMPUTER_LOCAL_IP = array("192.168.0.1","192.168.0.2");
 
-	// This is the Port being used by the Windows SleepOnLan Utility to initiate a Sleep State
+	// This is the Command Format (%s is the placeholder for machine ip address) being used by the Windows SleepOnLan Utility to initiate a Sleep State
 	// http://www.ireksoftware.com/SleepOnLan/
 	// Alternate Download Link: http://www.jeremyblum.com/wp-content/uploads/2013/07/SleepOnLan.zip
-	$COMPUTER_SLEEP_CMD_PORT = 7760;
-
-	// Command to be issued by the windows sleeponlan utility
-	// options are suspend, hibernate, logoff, poweroff, forcepoweroff, lock, reboot
-	// You can create a windows scheduled task that starts sleeponlan.exe on boot with following startup parameters /auto /port=7760
-	$COMPUTER_SLEEP_CMD = "suspend";
+	$COMPUTER_SLEEP_CMD_FORMAT = "curl -sSL -m 5 http://%s:7760/suspend";
 
 	// This is the location of the bootstrap style folder relative to your index and config file. Default = "" (Same folder as this file)
 	// Directory must be called "bootstrap". You may wish to move if this WOL script is the "child" of a larger web project on your Pi, that will also use bootstrap styling.

--- a/index.php
+++ b/index.php
@@ -209,14 +209,12 @@ else
 				elseif ($approved_sleep)
 				{
 					echo "<p>Approved. Sending Sleep Command...</p>";
-					$ch = curl_init();
-					curl_setopt($ch, CURLOPT_URL, "http://" . $COMPUTER_LOCAL_IP[$selectedComputer] . ":" . $COMPUTER_SLEEP_CMD_PORT . "/" .  $COMPUTER_SLEEP_CMD);
-					curl_setopt($ch, CURLOPT_TIMEOUT, 5);
-					curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 					
-					if (curl_exec($ch) === false)
+					$cmd = sprintf($COMPUTER_SLEEP_CMD_FORMAT . " 2>&1 >/dev/null", $COMPUTER_LOCAL_IP[$selectedComputer]);
+					exec($cmd, $output, $code);
+					if ($code != 0)
 					{
-						echo "<p><span style='color:#CC0000;'><b>Command Failed:</b></span> " . curl_error($ch) . "</p>";
+						echo "<p><span style='color:#CC0000;'><b>Command Failed:</b></span> " . join('<br>', $output) . "</p>";
 					}
 					else
 					{
@@ -248,7 +246,6 @@ else
 							echo "<p style='color:#CC0000;'><b>FAILED!</b> " . $COMPUTER_NAME[$selectedComputer] . " doesn't seem to be falling asleep... Try again?</p><p>(Or <a href='?computer=" . $selectedComputer . "'>Return to the Wake/Sleep Control Home</a>.)</p>";
 						}
 					}
-					curl_close($ch);
 				}
 				elseif (isset($_POST['submitbutton']))
 				{


### PR DESCRIPTION
Use a extenal command to fire the sleep request has below advantages

1. Decouple php-curl dependency
2. User could switch to other sleep implementations. e.g.
    - samba-common-bin
    `net rpc shutdown -f -I %s -U username%password`
    - ssh on windows (Bash on windows 10)
    `ssh user@%s powercfg -hibernate off`

Signed-off-by: phuslu <phuslu@hotmail.com>