### PR TITLE
Updating php to 7.4 because 7.3 is no longer supported with raspberry…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ def run_step(handle, description, dot_file_skippable=True):
 def _01_install_prereqs():
     try:
         subprocess.run(['sudo', 'apt-get', 'update'], check=True)
-        subprocess.run(['sudo', 'apt-get', '-y', 'install', 'wakeonlan', 'git', 'apache2', 'php7.3', 'php7.3-curl', 'libapache2-mod-php7.3', 'snapd'], check=True)
+        subprocess.run(['sudo', 'apt-get', '-y', 'install', 'wakeonlan', 'git', 'apache2', 'php7.4', 'php7.4-curl', 'libapache2-mod-php7.4', 'snapd'], check=True)
         subprocess.run(['sudo', 'snap', 'install', 'core'], check=True)
         subprocess.run(['sudo', 'snap', 'refresh', 'core'], check=True)
         subprocess.run(['sudo', 'apt-get', '-y', 'remove', 'certbot']) #Remove any existing installations from package managers


### PR DESCRIPTION
On several raspberry (1, 2 and 3) the program can not install because the version 7.3 of php is not found by the command apt. I just put the last version and the program works perfectly.