### PR TITLE
Change password verification to SHA-256 hashing

### DIFF
--- a/www/html/index.php
+++ b/www/html/index.php
@@ -110,7 +110,7 @@ else
             {
                 if (!is_null($APPROVED_HASH))
                 {
-                    if (password_verify($_POST['password'], $APPROVED_HASH))
+                    if (hash("sha256", $_POST['password']) === $APPROVED_HASH)
 	                {
 						if ($_POST['submitbutton'] == "Wake Up!")
 						{


### PR DESCRIPTION
Replaced password verification method with SHA-256 hash comparison.  Fixed authentication bug.

Replaced password_verify() with direct SHA-256 hash comparison: hash("sha256", $_POST['password']) === $APPROVED_HASH

The previous implementation always failed because $APPROVED_HASH contains a SHA-256 hash, not a password_hash() value.