### PR TITLE
Add GPIO relay hard power control

### DIFF
--- a/rwsols-relay
+++ b/rwsols-relay
@@ -1,0 +1,36 @@
+#!/bin/bash
+# RWSOLS GPIO Relay Helper
+# Controls a Digital Loggers IOT Relay via Raspberry Pi GPIO.
+# Installed to /usr/local/bin/rwsols-relay by setup.py.
+# Only permits get/on/off operations on valid BCM GPIO pins (0-27).
+
+PIN="$2"
+
+if ! [[ "$PIN" =~ ^[0-9]+$ ]] || [ "$PIN" -lt 0 ] || [ "$PIN" -gt 27 ]; then
+    echo "error: invalid pin" >&2
+    exit 1
+fi
+
+case "$1" in
+    get)
+        OUTPUT=$(pinctrl get "$PIN" 2>&1)
+        if echo "$OUTPUT" | grep -q '| hi'; then
+            echo "off"
+        elif echo "$OUTPUT" | grep -q '| lo\|| --'; then
+            echo "on"
+        else
+            echo "error: unable to read pin state" >&2
+            exit 1
+        fi
+        ;;
+    on)
+        pinctrl set "$PIN" op dl
+        ;;
+    off)
+        pinctrl set "$PIN" op dh
+        ;;
+    *)
+        echo "error: usage: rwsols-relay {get|on|off} <pin>" >&2
+        exit 1
+        ;;
+esac

--- a/rwsols-relay
+++ b/rwsols-relay
@@ -2,12 +2,24 @@
 # RWSOLS GPIO Relay Helper
 # Controls a Digital Loggers IOT Relay via Raspberry Pi GPIO.
 # Installed to /usr/local/bin/rwsols-relay by setup.py.
-# Only permits get/on/off operations on valid BCM GPIO pins (0-27).
+# Only permits get/on/off operations on pins explicitly configured in config.php.
 
+CONFIG="/var/www/html/config.php"
 PIN="$2"
 
-if ! [[ "$PIN" =~ ^[0-9]+$ ]] || [ "$PIN" -lt 0 ] || [ "$PIN" -gt 27 ]; then
+if ! [[ "$PIN" =~ ^[0-9]+$ ]]; then
     echo "error: invalid pin" >&2
+    exit 1
+fi
+
+ALLOWED_PINS=$(grep 'COMPUTER_RELAY_GPIO' "$CONFIG" 2>/dev/null | grep -oE 'array\([^)]+' | grep -oE '[0-9]+')
+if [ -z "$ALLOWED_PINS" ]; then
+    echo "error: no pins configured" >&2
+    exit 1
+fi
+
+if ! echo "$ALLOWED_PINS" | grep -qw "$PIN"; then
+    echo "error: pin $PIN not configured" >&2
     exit 1
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ def main():
     # Ping Permissions
     run_step('_02_ping_permissions', 'Grant Ping Permission')
 
+    # GPIO Relay Permissions
+    run_step('_02a_gpio_relay_permissions', 'Grant GPIO Relay Permissions')
+
     # Copy our web files to the Apache webroot
     run_step('_03_copy_webroot', 'Copy Unconfigured Webroot', False)
 
@@ -167,20 +170,42 @@ def _02_ping_permissions():
         return False
     return True
 
+# Setup Step 2a: Grant www-data permission to control GPIO pins via pinctrl for hard power relay control.
+def _02a_gpio_relay_permissions():
+    sudoers_file = '/etc/sudoers.d/rwsols-gpio'
+    sudoers_rule = 'www-data ALL=(root) NOPASSWD: /usr/bin/pinctrl\n'
+    try:
+        subprocess.run(['sudo', 'bash', '-c', 'echo "' + sudoers_rule.strip() + '" > ' + sudoers_file], check=True)
+        subprocess.run(['sudo', 'chmod', '440', sudoers_file], check=True)
+        subprocess.run(['sudo', 'usermod', '-aG', 'gpio', 'www-data'], check=True)
+    except subprocess.CalledProcessError:
+        print(yellow("Error setting GPIO relay permissions."))
+        return False
+    return True
+
 # Setup Step 3: Copy unconfigured webroot to default apache directory
 def _03_copy_webroot():
     wol_html_dir = script_dir.joinpath('www/html')
     apache_www_dir = pathlib.Path('/var/www')
     apache_html_dir = apache_www_dir.joinpath('html')
     try:
-        if directories_match(wol_html_dir, apache_html_dir):
+        try:
+            dirs_match = directories_match(wol_html_dir, apache_html_dir)
+        except (PermissionError, ValueError):
+            dirs_match = False
+
+        if dirs_match:
             print(cyan("Apache webroot contents already match local webroot contents. No update to be made."))
         else:
             print(yellow("The Apache webroot contents do not match local webroot."))
-            backup_dir_str = str(apache_www_dir) + "/html_backup_" + datetime.datetime.now().strftime("%Y-%m-%d_%H-%M")
-            subprocess.run(['sudo', 'mv', str(apache_html_dir), backup_dir_str], check=True)
-            print(yellow("Apache webroot backed up to " + backup_dir_str))
+            if apache_html_dir.exists():
+                backup_dir_str = str(apache_www_dir) + "/html_backup_" + datetime.datetime.now().strftime("%Y-%m-%d_%H-%M")
+                subprocess.run(['sudo', 'mv', str(apache_html_dir), backup_dir_str], check=True)
+                print(yellow("Apache webroot backed up to " + backup_dir_str))
             subprocess.run(['sudo', 'cp', '-R', str(wol_html_dir), str(apache_www_dir)], check=True)
+            subprocess.run(['sudo', 'chown', '-R', 'www-data:www-data', str(apache_html_dir)], check=True)
+            subprocess.run(['sudo', 'find', str(apache_html_dir), '-type', 'd', '-exec', 'chmod', '755', '{}', ';'], check=True)
+            subprocess.run(['sudo', 'find', str(apache_html_dir), '-type', 'f', '-exec', 'chmod', '644', '{}', ';'], check=True)
             print(cyan("Website contents copied to Apache webroot."))
     except Exception as e:
         print(yellow("Error moving website contents to Apache webroot folder."))

--- a/setup.py
+++ b/setup.py
@@ -170,13 +170,15 @@ def _02_ping_permissions():
         return False
     return True
 
-# Setup Step 2a: Grant www-data permission to control GPIO pins via pinctrl for hard power relay control.
+# Setup Step 2a: Install the GPIO relay helper script and grant www-data permission to run it via sudo.
 def _02a_gpio_relay_permissions():
+    relay_script_src = script_dir.joinpath('rwsols-relay')
+    relay_script_dst = '/usr/local/bin/rwsols-relay'
     sudoers_file = '/etc/sudoers.d/rwsols-gpio'
-    sudoers_rule = 'www-data ALL=(root) NOPASSWD: /usr/bin/pinctrl\n'
+    sudoers_rule = 'www-data ALL=(root) NOPASSWD: ' + relay_script_dst
     try:
-        subprocess.run(['sudo', 'bash', '-c', 'echo "' + sudoers_rule.strip() + '" > ' + sudoers_file], check=True)
-        subprocess.run(['sudo', 'chmod', '440', sudoers_file], check=True)
+        subprocess.run(['sudo', 'install', '-m', '755', str(relay_script_src), relay_script_dst], check=True)
+        subprocess.run(['sudo', 'install', '-m', '440', '/dev/stdin', sudoers_file], input=sudoers_rule.encode(), check=True)
         subprocess.run(['sudo', 'usermod', '-aG', 'gpio', 'www-data'], check=True)
     except subprocess.CalledProcessError:
         print(yellow("Error setting GPIO relay permissions."))

--- a/www/html/config_sample.php
+++ b/www/html/config_sample.php
@@ -40,6 +40,14 @@ $COMPUTER_MAC = array("00:00:00:00:00:00","00:00:00:00:00:00");
 // This is the LOCAL IP address of the computer you are trying to wake.  Use a reserved DHCP through your router's administration interface to ensure it doesn't change.
 $COMPUTER_LOCAL_IP = array("192.168.0.1","192.168.0.2");
 
+// This is the BCM GPIO pin number (integer) on the Raspberry Pi that controls a Digital Loggers IOT Relay for hard power control.
+// Use the integer BCM pin number only (e.g. 17, not "17" or "GPIO17").
+// The controlled computer should be plugged into the relay's "Normally On" outlet.
+// When the GPIO goes HIGH, the relay energizes and the "Normally On" outlet loses power (hard power off).
+// When the GPIO is LOW (default), the "Normally On" outlet has power (normal operation).
+// Set to NULL for computers without GPIO relay control.
+$COMPUTER_RELAY_GPIO = array(NULL, NULL);
+
 // This is the Port being used by the Windows SleepOnLan Utility to initiate a Sleep State
 // http://www.ireksoftware.com/SleepOnLan/
 // Alternate Download Link: http://www.jeremyblum.com/wp-content/uploads/2013/07/SleepOnLan.zip

--- a/www/html/index.php
+++ b/www/html/index.php
@@ -9,6 +9,29 @@ License: GPL v3 (http://www.gnu.org/licenses/gpl.html)
 //You should not need to edit this file. Adjust Parameters in the config file:
 require_once('config.php');
 
+// Backward compatibility for configs without GPIO relay support
+if (!isset($COMPUTER_RELAY_GPIO)) {
+    $COMPUTER_RELAY_GPIO = array_fill(0, count($COMPUTER_NAME), NULL);
+}
+
+// GPIO relay helpers for Digital Loggers IOT Relay ("Normally On" outlet)
+// GPIO HIGH = relay energized = outlet OFF | GPIO LOW = relay de-energized = outlet ON
+function getRelayPowerState($pin) {
+    $output = shell_exec('sudo pinctrl get ' . intval($pin) . ' 2>&1');
+    if (strpos($output, '| hi') !== false) {
+        return 'off';
+    }
+    return 'on';
+}
+
+function setRelayPower($pin, $powerOn) {
+    if ($powerOn) {
+        exec('sudo pinctrl set ' . intval($pin) . ' op dl');
+    } else {
+        exec('sudo pinctrl set ' . intval($pin) . ' op dh');
+    }
+}
+
 //set headers that harden the HTTPS session
 if ($USE_HTTPS)
 {
@@ -104,7 +127,10 @@ else
     		$approved = false;
 			$wake_up = false;
 			$go_to_sleep = false;
+			$hard_power_off = false;
+			$hard_power_on = false;
 			$check_current_status = false;
+			$relay_power_on = null;
 
 			if ( isset($_POST['password']) )
             {
@@ -126,6 +152,16 @@ else
 						{
 							$approved = true;
 							$check_current_status = true;
+						}
+						elseif ($_POST['submitbutton'] == "Hard Power Off!")
+						{
+							$approved = true;
+							$hard_power_off = true;
+						}
+						elseif ($_POST['submitbutton'] == "Hard Power On!")
+						{
+							$approved = true;
+							$hard_power_on = true;
 						}
 					}
                 }
@@ -153,6 +189,10 @@ else
 					echo "Waking Up!";
 				} elseif ($go_to_sleep) {
 					echo "Going to Sleep!";
+				} elseif ($hard_power_off) {
+					echo "Cutting Power!";
+				} elseif ($hard_power_on) {
+					echo "Restoring Power!";
 				} else {?>
                     <select name="computer" onchange="if (this.value) window.location.href='?computer=' + this.value">
                     <?php
@@ -195,6 +235,17 @@ else
 					{
 						$asleep = false;
 						echo "<h5>" . $COMPUTER_NAME[$selectedComputer] . " is presently awake.</h5>";
+					}
+
+					if (!is_null($COMPUTER_RELAY_GPIO[$selectedComputer]))
+					{
+						$relayState = getRelayPowerState($COMPUTER_RELAY_GPIO[$selectedComputer]);
+						$relay_power_on = ($relayState == 'on');
+						if ($relay_power_on) {
+							echo "<h5>Hard Power Relay: <span style='color:#00CC00;'>ON</span></h5>";
+						} else {
+							echo "<h5>Hard Power Relay: <span style='color:#CC0000;'>OFF</span></h5>";
+						}
 					}
 
                 }
@@ -278,6 +329,95 @@ else
 					}
 					curl_close($ch);
 				}
+				elseif ($hard_power_off)
+				{
+					$gpioPin = $COMPUTER_RELAY_GPIO[$selectedComputer];
+					echo "<p>Approved. Cutting hard power to " . $COMPUTER_NAME[$selectedComputer] . "...</p>";
+					setRelayPower($gpioPin, false);
+					$state = getRelayPowerState($gpioPin);
+					if ($state == 'off')
+					{
+						echo "<p><span style='color:#00CC00;'><b>Power Cut!</b></span> Waiting for " . $COMPUTER_NAME[$selectedComputer] . " to go down...</p><p>";
+						$count = 1;
+						$down = false;
+						while ($count <= $MAX_PINGS && $down == false)
+						{
+							echo "Ping " . $count . "...";
+							$pinginfo = exec("ping -c 1 " . $COMPUTER_LOCAL_IP[$selectedComputer]);
+							$count++;
+							if ($pinginfo == "")
+							{
+								$down = true;
+								echo "<span style='color:#00CC00;'><b>Confirmed Down.</b></span><br />";
+								echo "<p><a href='?computer=" . $selectedComputer . "'>Return to the Wake/Sleep Control Home</a></p>";
+								$show_form = false;
+							}
+							else
+							{
+								echo "<span style='color:#CC0000;'><b>Still Responding.</b></span><br />";
+							}
+							sleep($SLEEP_TIME);
+						}
+						echo "</p>";
+						if ($down == false)
+						{
+							echo "<p><span style='color:#00CC00;'><b>Power is cut.</b></span> " . $COMPUTER_NAME[$selectedComputer] . " may still be shutting down.</p><p><a href='?computer=" . $selectedComputer . "'>Return to the Wake/Sleep Control Home</a></p>";
+							$show_form = false;
+						}
+					}
+					else
+					{
+						echo "<p style='color:#CC0000;'><b>FAILED!</b> Could not cut power to " . $COMPUTER_NAME[$selectedComputer] . ". Check GPIO configuration.</p>";
+						$asleep = false;
+						$relay_power_on = true;
+					}
+				}
+				elseif ($hard_power_on)
+				{
+					$gpioPin = $COMPUTER_RELAY_GPIO[$selectedComputer];
+					echo "<p>Approved. Restoring hard power to " . $COMPUTER_NAME[$selectedComputer] . "...</p>";
+					setRelayPower($gpioPin, true);
+					$state = getRelayPowerState($gpioPin);
+					if ($state == 'on')
+					{
+						echo "<p><span style='color:#00CC00;'><b>Power Restored!</b></span></p>";
+						echo "<p>Sending WOL Command...</p>";
+						exec('wakeonlan ' . $COMPUTER_MAC[$selectedComputer]);
+						echo "<p>Waiting for " . $COMPUTER_NAME[$selectedComputer] . " to come up...</p><p>";
+						$count = 1;
+						$down = true;
+						while ($count <= $MAX_PINGS && $down == true)
+						{
+							echo "Ping " . $count . "...";
+							$pinginfo = exec("ping -c 1 " . $COMPUTER_LOCAL_IP[$selectedComputer]);
+							$count++;
+							if ($pinginfo != "")
+							{
+								$down = false;
+								echo "<span style='color:#00CC00;'><b>It's Alive!</b></span><br />";
+								echo "<p><a href='?computer=" . $selectedComputer . "'>Return to the Wake/Sleep Control Home</a></p>";
+								$show_form = false;
+							}
+							else
+							{
+								echo "<span style='color:#CC0000;'><b>Still Down.</b></span><br />";
+							}
+							sleep($SLEEP_TIME);
+						}
+						echo "</p>";
+						if ($down == true)
+						{
+							echo "<p style='color:#CC0000;'><b>Note:</b> Power was restored, but " . $COMPUTER_NAME[$selectedComputer] . " hasn't responded yet. The BIOS may not be set to auto-boot on AC restore. Try Wake Up!</p><p><a href='?computer=" . $selectedComputer . "'>Return to the Wake/Sleep Control Home</a></p>";
+							$show_form = false;
+						}
+					}
+					else
+					{
+						echo "<p style='color:#CC0000;'><b>FAILED!</b> Could not restore power to " . $COMPUTER_NAME[$selectedComputer] . ". Check GPIO configuration.</p>";
+						$asleep = true;
+						$relay_power_on = false;
+					}
+				}
 				elseif (isset($_POST['submitbutton']))
 				{
 					echo "<p style='color:#CC0000;'><b>Invalid Passphrase. Request Denied.</b></p>";
@@ -285,17 +425,32 @@ else
                 
                 if ($show_form)
                 {
+					// Query relay state for button rendering if not already known
+					if (!is_null($COMPUTER_RELAY_GPIO[$selectedComputer]) && $relay_power_on === null) {
+						$relay_power_on = (getRelayPowerState($COMPUTER_RELAY_GPIO[$selectedComputer]) == 'on');
+					}
             ?>
         			<input type="password" autocomplete=off class="input-block-level" placeholder="Enter Passphrase" <?php if (isset($approved) && $approved == true) {echo "value='" . $_POST['password'] . "'";} ?> name="password">
         			<?php if ( !isset($_POST['submitbutton']) || ($approved == false) ) { ?>
         			    <input class="btn btn-large btn-primary" type="submit" name="submitbutton" value="Check Status"/>
 						<input type="hidden" name="submitbutton" value="Check Status" />  <!-- handle if IE used and enter button pressed instead of sleep button -->
-                    <?php } elseif (  $asleep ) { ?>
+                    <?php } elseif ( !is_null($COMPUTER_RELAY_GPIO[$selectedComputer]) && $relay_power_on === false ) { ?>
+						<input class="btn btn-large btn-success" type="submit" name="submitbutton" value="Hard Power On!"/>
+						<input type="hidden" name="submitbutton" value="Hard Power On!" />
+                    <?php } elseif ( $asleep ) { ?>
         				<input class="btn btn-large btn-primary" type="submit" name="submitbutton" value="Wake Up!"/>
 						<input type="hidden" name="submitbutton" value="Wake Up!"/>  <!-- handle if IE used and enter button pressed instead of wake up button -->
+						<?php if (!is_null($COMPUTER_RELAY_GPIO[$selectedComputer])) { ?>
+							<br /><br />
+							<input class="btn btn-large btn-danger" type="submit" name="submitbutton" value="Hard Power Off!"/>
+						<?php } ?>
                     <?php } else { ?>
 		                <input class="btn btn-large btn-primary" type="submit" name="submitbutton" value="Sleep!"/>
 						<input type="hidden" name="submitbutton" value="Sleep!" />  <!-- handle if IE used and enter button pressed instead of sleep button -->
+						<?php if (!is_null($COMPUTER_RELAY_GPIO[$selectedComputer])) { ?>
+							<br /><br />
+							<input class="btn btn-large btn-danger" type="submit" name="submitbutton" value="Hard Power Off!"/>
+						<?php } ?>
                     <?php } ?>
 	
 			<?php

--- a/www/html/index.php
+++ b/www/html/index.php
@@ -338,8 +338,11 @@ else
 				elseif ($hard_power_off)
 				{
 					$gpioPin = $COMPUTER_RELAY_GPIO[$selectedComputer];
-					echo "<p>Approved. Cutting hard power to " . $COMPUTER_NAME[$selectedComputer] . "...</p>";
-					if (setRelayPower($gpioPin, false))
+					if (is_null($gpioPin))
+					{
+						echo "<p style='color:#CC0000;'><b>FAILED!</b> " . $COMPUTER_NAME[$selectedComputer] . " has no relay configured.</p>";
+					}
+					elseif (setRelayPower($gpioPin, false))
 					{
 						echo "<p><span style='color:#00CC00;'><b>Power Cut!</b></span> Waiting for " . $COMPUTER_NAME[$selectedComputer] . " to go down...</p><p>";
 						$count = 1;
@@ -379,8 +382,11 @@ else
 				elseif ($hard_power_on)
 				{
 					$gpioPin = $COMPUTER_RELAY_GPIO[$selectedComputer];
-					echo "<p>Approved. Restoring hard power to " . $COMPUTER_NAME[$selectedComputer] . "...</p>";
-					if (setRelayPower($gpioPin, true))
+					if (is_null($gpioPin))
+					{
+						echo "<p style='color:#CC0000;'><b>FAILED!</b> " . $COMPUTER_NAME[$selectedComputer] . " has no relay configured.</p>";
+					}
+					elseif (setRelayPower($gpioPin, true))
 					{
 						echo "<p><span style='color:#00CC00;'><b>Power Restored!</b></span></p>";
 						echo "<p>Sending WOL Command...</p>";

--- a/www/html/index.php
+++ b/www/html/index.php
@@ -13,23 +13,26 @@ require_once('config.php');
 if (!isset($COMPUTER_RELAY_GPIO)) {
     $COMPUTER_RELAY_GPIO = array_fill(0, count($COMPUTER_NAME), NULL);
 }
-
-// GPIO relay helpers for Digital Loggers IOT Relay ("Normally On" outlet)
-// GPIO HIGH = relay energized = outlet OFF | GPIO LOW = relay de-energized = outlet ON
-function getRelayPowerState($pin) {
-    $output = shell_exec('sudo pinctrl get ' . intval($pin) . ' 2>&1');
-    if (strpos($output, '| hi') !== false) {
-        return 'off';
-    }
-    return 'on';
+// Pad the array if it's shorter than the computer list (user added computers but forgot to extend)
+while (count($COMPUTER_RELAY_GPIO) < count($COMPUTER_NAME)) {
+    $COMPUTER_RELAY_GPIO[] = NULL;
 }
 
-function setRelayPower($pin, $powerOn) {
-    if ($powerOn) {
-        exec('sudo pinctrl set ' . intval($pin) . ' op dl');
-    } else {
-        exec('sudo pinctrl set ' . intval($pin) . ' op dh');
+// GPIO relay helpers using the rwsols-relay script (installed to /usr/local/bin by setup.py)
+// Returns 'on', 'off', or null on error
+function getRelayPowerState($pin) {
+    $output = trim(shell_exec('sudo /usr/local/bin/rwsols-relay get ' . intval($pin) . ' 2>/dev/null'));
+    if ($output === 'on' || $output === 'off') {
+        return $output;
     }
+    return null;
+}
+
+// Returns true on success, false on failure
+function setRelayPower($pin, $powerOn) {
+    $cmd = $powerOn ? 'on' : 'off';
+    exec('sudo /usr/local/bin/rwsols-relay ' . $cmd . ' ' . intval($pin), $output, $result_code);
+    return $result_code === 0;
 }
 
 //set headers that harden the HTTPS session
@@ -240,10 +243,13 @@ else
 					if (!is_null($COMPUTER_RELAY_GPIO[$selectedComputer]))
 					{
 						$relayState = getRelayPowerState($COMPUTER_RELAY_GPIO[$selectedComputer]);
-						$relay_power_on = ($relayState == 'on');
-						if ($relay_power_on) {
+						if ($relayState === null) {
+							echo "<h5>Hard Power Relay: <span style='color:#CC0000;'>ERROR - Unable to read state</span></h5>";
+						} elseif ($relayState == 'on') {
+							$relay_power_on = true;
 							echo "<h5>Hard Power Relay: <span style='color:#00CC00;'>ON</span></h5>";
 						} else {
+							$relay_power_on = false;
 							echo "<h5>Hard Power Relay: <span style='color:#CC0000;'>OFF</span></h5>";
 						}
 					}
@@ -333,9 +339,7 @@ else
 				{
 					$gpioPin = $COMPUTER_RELAY_GPIO[$selectedComputer];
 					echo "<p>Approved. Cutting hard power to " . $COMPUTER_NAME[$selectedComputer] . "...</p>";
-					setRelayPower($gpioPin, false);
-					$state = getRelayPowerState($gpioPin);
-					if ($state == 'off')
+					if (setRelayPower($gpioPin, false))
 					{
 						echo "<p><span style='color:#00CC00;'><b>Power Cut!</b></span> Waiting for " . $COMPUTER_NAME[$selectedComputer] . " to go down...</p><p>";
 						$count = 1;
@@ -376,9 +380,7 @@ else
 				{
 					$gpioPin = $COMPUTER_RELAY_GPIO[$selectedComputer];
 					echo "<p>Approved. Restoring hard power to " . $COMPUTER_NAME[$selectedComputer] . "...</p>";
-					setRelayPower($gpioPin, true);
-					$state = getRelayPowerState($gpioPin);
-					if ($state == 'on')
+					if (setRelayPower($gpioPin, true))
 					{
 						echo "<p><span style='color:#00CC00;'><b>Power Restored!</b></span></p>";
 						echo "<p>Sending WOL Command...</p>";
@@ -427,7 +429,10 @@ else
                 {
 					// Query relay state for button rendering if not already known
 					if (!is_null($COMPUTER_RELAY_GPIO[$selectedComputer]) && $relay_power_on === null) {
-						$relay_power_on = (getRelayPowerState($COMPUTER_RELAY_GPIO[$selectedComputer]) == 'on');
+						$relayState = getRelayPowerState($COMPUTER_RELAY_GPIO[$selectedComputer]);
+						if ($relayState !== null) {
+							$relay_power_on = ($relayState == 'on');
+						}
 					}
             ?>
         			<input type="password" autocomplete=off class="input-block-level" placeholder="Enter Passphrase" <?php if (isset($approved) && $approved == true) {echo "value='" . $_POST['password'] . "'";} ?> name="password">


### PR DESCRIPTION
## Summary
- Adds hard power on/off capability via a Digital Loggers IOT Relay (or equivalent) connected to a Pi GPIO pin
- New `$COMPUTER_RELAY_GPIO` config array (per-computer, NULL for no relay) with graceful backward compatibility for older configs
- UI shows relay power state after status check, with "Hard Power Off!" (red) and "Hard Power On!" (green) buttons
- "Hard Power On!" also sends a WOL magic packet after restoring power
- Setup script creates sudoers rule for `www-data` to run `pinctrl`, adds `www-data` to `gpio` group
- Fixes webroot copy permissions bug (chown/chmod after cp) and handles missing `/var/www/html` gracefully
- Wiki updated with hardware setup instructions, terminology, and FAQ entries

## Test plan
- [ ] Verify page loads correctly for computers without GPIO configured (backward compat)
- [ ] Verify relay state displays correctly after status check for GPIO-configured computers
- [ ] Test "Hard Power Off!" cuts power (GPIO goes high, relay energizes)
- [ ] Test "Hard Power On!" restores power and sends WOL
- [ ] Verify setup script `_02a_gpio_relay_permissions` step creates sudoers file and adds gpio group
- [ ] Verify setup script webroot copy sets correct ownership/permissions
- [ ] Confirm graceful handling when `$COMPUTER_RELAY_GPIO` is absent from config